### PR TITLE
change: add latest tag to docker image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,10 @@ jobs:
       with:
         context: .
         push: true
-        tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}
+        tags: |
+          ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          ${{ env.IMAGE_NAME }}:latest
+
 
     - id: 'deploy'
       uses: 'google-github-actions/deploy-cloudrun@v0'


### PR DESCRIPTION
Terraform requires latest tag when doing initial deployments

## Changelog
### Change:
- add latest tag to most recent docker image 