### PR TITLE
fix-login-url-for-username-and-password

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,7 +44,8 @@ def login():
     '__RequestVerificationToken': login_request_verification_token
   }
 
-  login_page = session.post(shared.base_url + '/CWS/Home/Index', login_credentials)
+  # ⬇ NOTE: Rejsekort changed the Username login URL from Index to UserNameLogin
+  login_page = session.post(shared.base_url + '/CWS/Home/UserNameLogin', login_credentials)
   soup = BeautifulSoup(login_page.text, "html.parser")
   token = shared.get_verification_token(login_page)
 


### PR DESCRIPTION
Rejsekort happened to change the `username` + `password` login from `CMS/Home/Index` to `CMS/Home/UserNameLogin`.
This completely broke the service.

This PR aims to fix that broken login URL.

## Changelog:
### Fix:
- broken login url from `CMS/Home/Index` to `CMS/Home/UserNameLogin`