### PR TITLE
separate authentication from travel history functions

### DIFF
--- a/functions/authenticate.py
+++ b/functions/authenticate.py
@@ -1,0 +1,108 @@
+from functions import shared, user, card
+import json, re, logging
+from bs4 import BeautifulSoup
+from datetime import datetime, timedelta
+
+def login(username, password):
+
+    # Get Login Page HTML
+    # Timeout after 10seconds
+    login_page_html = shared.session.get(shared.base_url + '/CWS/Home/UserNameLogin', timeout=shared.requests_timeout)
+    request_verification_token = shared.get_verification_token(login_page_html.text)
+
+    # Build post data for login
+    credentials = {
+        'Username': username,
+        'Password': password,
+        '__RequestVerificationToken': request_verification_token
+    }
+
+    # ⬇ NOTE: Rejsekort changed the Username login URL from Index to UserNameLogin
+    response = shared.session.post(shared.base_url + '/CWS/Home/UserNameLogin', credentials)
+    soup = BeautifulSoup(response.text, "html.parser")    
+
+    print(f"Login Status: {is_login_successful(soup)}")
+
+    # Check if login_page contains error in response and return message to user.
+    # Otherwise, continue to get user details and travel history
+
+    # TODO: fix error string/message to search for in place of YaNeverKNOW
+    if is_login_successful(soup):
+        # Login was successful
+        details = user.get_details()
+        active_cards = soup.find_all('div', class_='ActiveCard')
+        cards = card.get_details(active_cards, shared.session.cookies.get_dict())
+
+        login_time = ""
+        login_expiry = ""
+        
+        try:
+            login_time = datetime.strptime(response.headers['Date'], '%a, %d %b %Y %H:%M:%S GMT')
+            login_expiry = login_time + timedelta(hours=3) # 3 hours
+        except Exception as e:
+            logging.error(f"Error parsing cookie datetime from header: {e}")
+
+        user_details = {
+            "user": details,
+            "cards": cards,
+            "credentials": {    
+                "username": username,
+                "password": password,
+                "cookies": {
+                    "data": shared.session.cookies.get_dict(),
+                    "issue": str(login_time),
+                    "expiry": str(login_expiry)
+                }
+            }
+        }
+
+        # print(json.dumps(shared.session.cookies.get_dict(), indent=2, ensure_ascii=False))
+        
+        # Clear Session Cookies for next request
+        shared.session.cookies.clear()
+        shared.session.close()
+
+        return json.dumps(user_details, indent=2, ensure_ascii=False)
+        # end successful login
+            
+    # error_on_login_page = re.search(r'Sorry. A technical error has occurred', login_page.text)
+    elif is_login_failed(soup):
+        # Error Loggin In. Clear Session Cookies for next request
+        # StatusCode 401 is unauthorized/unauthenticated
+        shared.session.cookies.clear()
+        shared.session.close()
+        login_error = {"Login Failed": "Username or Password is incorrect. Please try again."}
+        return json.dumps(login_error, indent=2, ensure_ascii=False)
+    elif login_page_html.status_code == 500:
+        # Close and Clear Session Cookies for next request
+        shared.session.cookies.clear()
+        shared.session.close()
+        timeout_error = {"Login Failed": "Request timed out. Please try again later."}
+        return json.dumps(timeout_error, indent=2, ensure_ascii=False)
+    else:
+        # Close and Clear Session Cookies for next request
+        shared.session.cookies.clear()
+        shared.session.close()
+        timeout_error = {"Login Failed": "Something else went wrong. Please try again later."}
+        return json.dumps(timeout_error, indent=2, ensure_ascii=False)
+        
+
+def is_login_required(html_page):
+    if html_page.find(string="Sorry. A technical error has occurred.") or html_page.find(string="Go to Log in"):
+        return True
+    else:
+        return False
+ 
+
+def is_login_failed(page):
+    if page.find(string="Sorry. A technical error has occurred.") or page.find(string="Go to Log in") or page.find(string="Dit brugernavn eller din adgangskode er indtastet forkert.") or page.find(string="The username or password is incorrect") or page.find(string="The username or password is incorrect."): 
+        return True
+    else:
+        return False
+
+
+def is_login_successful(page):
+    if page.find_all('div', class_='ActiveCard'):
+        return True
+    else:
+        return False

--- a/functions/card.py
+++ b/functions/card.py
@@ -1,34 +1,16 @@
 import logging
 from socket import timeout
 from typing import Dict, List
-
 from functions import shared
 from bs4 import BeautifulSoup
-import re
+import re, json, cProfile, requests
 import concurrent.futures
 
 
-def fetch_card_expiry(prefix, session, token):
-    """
-    Fetch the card expiry date from the website using the provided session and token.
-
-    Args:
-    - prefix (str): The prefix used to construct the URL for fetching card details.
-    - session: An instance of the session used for making the request.
-    - token (str): The token used for fetching card details.
-    - timeout (int): The number of seconds to wait for a response from the server.
-
-    Returns:
-    - str: The card expiry date in the format 'MM/DD/YYYY'
-
-    Raises:
-    - ValueError: If the div class 'my_reload_agreement_left' is not found in the HTML page.
-    - ValueError: If the expiry date is not found in the HTML page.
-    - Exception: If any other error occurs during the request.
-    """
+def get_expiry(prefix, cookies):
+    shared.session.cookies.update(cookies)
     try:
-        details = session.get(f"{shared.base_url}/CWS/CardServices/Overview/{prefix}",
-                              data={'__RequestVerificationToken': token}, timeout=shared.requests_timeout)
+        details = shared.session.get(f"{shared.base_url}/CWS/CardServices/Overview/{prefix}", timeout=shared.requests_timeout)
 
         expiry_date = re.search(r'\d{2}/\d{2}/\d{4}', details.text)
         if expiry_date is None:
@@ -38,99 +20,7 @@ def fetch_card_expiry(prefix, session, token):
         print(f"An error occurred: {e}")
 
 
-def get_paginated_travel_history(session, prefix, token):
-    """
-    Retrieves all paginated data from a table and return it in the form of a list of dictionaries
-
-    Parameters:
-    session (Session) : session object to handle the connection with the server
-    prefix (str) : prefix for the url
-    token (str) : token for the request
-
-    Returns:
-    List[Dict[str,str]] : list of dictionaries containing the data
-    """
-
-    page = 1
-    has_next = True
-    rows = []
-
-    while has_next:
-        url = shared.base_url + '/CWS/TransactionServices/TravelCardHistory/' + prefix
-        params = {'periodSelected': 'All', '__RequestVerificationToken': token, 'page': page}
-        history = session.get(url, params=params, timeout=shared.requests_timeout)
-        soup = BeautifulSoup(history.text, "lxml")
-
-        pages = len(soup.find_all('div', {"class": "historyPage"}))
-
-        # find all rows in the table
-        data = soup.find_all('tr')
-        rows.extend(data)
-
-        # check if there is a 'Next' button in the pagination
-        pagination = soup.find_all('span', {"class": "paginationButton"}, {"name": "goToPage"})
-        has_next = any('Next' in result.text for result in pagination)
-
-        if has_next:
-            page += pages
-
-    # get the headers from the first row
-    headers = [th.text for th in rows[0].find_all('th')]
-
-    dataset = [{headers[i]: cell.text.strip() for i, cell in enumerate(row.find_all('td'))} for row in rows[1:]]
-
-    return dataset
-
-
-def fetch_travel_history(prefix, session, token):
-    """
-    Retrieves the travel history data, separates it into orders and journeys, and returns it as a dictionary
-
-    Parameters:
-    prefix (str) : prefix for the url
-    session (Session) : session object to handle the connection with the server
-    token (str) : token for the request
-
-    Returns:
-    Dict[str, List[Dict[str,str]]] : dictionary containing the data for orders and journeys
-    """
-    # cProfile.run(get_paginated_travel_history(session, prefix, token))
-    dataset = get_paginated_travel_history(session, prefix, token)
-
-    orders = list(filter(
-        lambda x: "Reload agreement" in x.values() or "Reload" in x.values() or "Rejsekort ordered" in x.values(),
-        dataset))
-    # Remove empty key-values and empty objects from orders
-    orders = [{k: v for k, v in d.items() if v} for d in orders]
-
-    journeys = list(filter(lambda x: x not in orders, dataset))
-    # Remove empty key-values and empty objects from journeys
-    journeys = [{k: v for k, v in d.items() if v} for d in journeys]
-
-    travel_data: dict[str, list[dict]] = {
-        "journeys": list(filter(bool, journeys)),
-        "orders": list(filter(bool, orders))
-    }
-
-    return travel_data
-
-
-def extract_card_details(cards, session, token):
-    """
-    Extract card details from the provided cards using the provided session and token.
-
-    Args:
-    - cards (bs4.element.ResultSet): A result set of card elements.
-    - session: An instance of the session used for making the request.
-    - token (str): The token used for fetching card details.
-
-    Returns:
-    - list: A list of dictionaries containing card details.
-
-    Raises:
-    - ValueError: If any required card details are missing.
-    """
-
+def get_details(cards, cookies):
     cards_list = []
     for card in cards:
         card_elements = card.find_all('div', class_='my_rejsekort_card_element')
@@ -138,25 +28,22 @@ def extract_card_details(cards, session, token):
             if card_element.find("div", class_="customer_name") and card_element.find('span', class_='bold right'):
                 try:
                     customer_name = card_element.find("div", class_="customer_name").string.strip()
-                    card_balance = card_element.find('span', class_='bold right').string + ' kr'
-                    card_link = None
-                    card_prefix = None
+                    balance = card_element.find('span', class_='bold right').string + ' kr'
+                    link = None
+                    prefix = None
                     if card_element.find('a'):
-                        card_link = card_element.find('a')
-                        card_prefix = card_link['href'].split('/')[-1]
-                    card_expiry_date = fetch_card_expiry(card_prefix, session, token)
-                    history = fetch_travel_history(card_prefix, session, token)
+                        link = card_element.find('a')
+                        prefix = link['href'].split('/')[-1]
+                    # card_expiry_date = get_expiry(prefix, cookies)
 
                     data = {
                         'name': customer_name,
-                        'number': card_link.text,
-                        'balance': card_balance,
-                        'electric_number': card_prefix.split("cardElectronicNumber=")[1],
-                        'prefix': card_prefix,
-                        'expiry_date': card_expiry_date,
+                        'number': link.text,
+                        'balance': balance,
+                        'electric_number': prefix.split("cardElectronicNumber=")[1],
+                        'prefix': prefix,
+                        # 'expiry_date': card_expiry_date,
                         'status': 'active',
-                        'journeys': history["journeys"],
-                        'orders': history["orders"]
                     }
 
                     cards_list.append(data)
@@ -169,6 +56,7 @@ def extract_card_details(cards, session, token):
             #     pass
 
     return cards_list
+
 
 # MyDiscount
 # ChangeCad: /CWS/CardServices/MyDiscount

--- a/functions/shared.py
+++ b/functions/shared.py
@@ -1,4 +1,4 @@
-import re
+import re, requests
 from bs4 import BeautifulSoup
 
 base_url = "https://selvbetjening.rejsekort.dk"
@@ -9,23 +9,10 @@ requests_timeout = 10
 
 pattern = re.compile(r'<input[^>]*name="__RequestVerificationToken"[^>]*>')
 
+session = requests.Session()
+
 
 def get_verification_token(html_page):
-    """
-    Extract the __RequestVerificationToken from the HTML page.
-
-    Args:
-    html_page (str): The HTML page to extract the token from.
-
-    Returns:
-    str: The __RequestVerificationToken value.
-
-    Raises:
-    ValueError: If the __RequestVerificationToken input tag is not found in the HTML page.
-    TypeError: If the html_page is not a string
-    ValueError: If the html_page is empty
-    """
-
     if not isinstance(html_page, str):
         raise TypeError("html_page must be a string.")
     if not html_page:
@@ -45,3 +32,11 @@ def get_verification_token(html_page):
     except KeyError:
         raise ValueError("__RequestVerificationToken input tag not contain value attribute.")
     return token
+
+
+def get_request_verification_token():
+    # Get Login Page HTML
+    # Timeout after 10seconds
+    login_page_html = session.get(base_url + '/CWS/Home/UserNameLogin', timeout=requests_timeout)
+    login_request_verification_token = get_verification_token(login_page_html.text)
+    return login_request_verification_token

--- a/functions/travel.py
+++ b/functions/travel.py
@@ -1,0 +1,72 @@
+import json
+import logging as log
+from bs4 import BeautifulSoup
+from functions import shared, authenticate
+
+def get_paginated_history(cookies, prefix, periodSelected='ThreeMonths'):
+    page = 1
+    has_next = True
+    rows = []
+    
+    shared.session.cookies.update(cookies)
+
+    while has_next:
+        url = shared.base_url + '/CWS/TransactionServices/TravelCardHistory/' + prefix
+        params = {'periodSelected': periodSelected, 'page': page}
+        
+        try:
+            history = shared.session.get(url, params=params, timeout=shared.requests_timeout)
+            soup = BeautifulSoup(history.text, "lxml")
+
+            pages = len(soup.find_all('div', {"class": "historyPage"}))
+
+            # find all rows in the table
+            data = soup.find_all('tr')
+
+            rows.extend(data)
+
+            # check if there is a 'Next' button in the pagination
+            pagination = soup.find_all('span', {"class": "paginationButton"}, {"name": "goToPage"})
+            has_next = any('Next' in result.text for result in pagination)
+
+            if has_next:
+                page += pages
+        except Exception as e:
+            log.error(f"Error fetching travel history: {e}")
+            return []
+
+    # get the headers from the first row
+    if not rows:
+        return []
+    else:
+        headers = [th.text for th in rows[0].find_all('th')]
+        dataset = [{headers[i]: cell.text.strip() for i, cell in enumerate(row.find_all('td'))} for row in rows[1:]]
+        return dataset
+
+
+def get_history(cookies, prefix, periodSelected='OneWeek'):
+    # cProfile.run(get_paginated_travel_history(session, prefix, token))
+    dataset = get_paginated_history(cookies, prefix, periodSelected)
+    data = {}
+
+    # print(credentials["cookies"])
+
+    if not dataset:
+        return json.dumps({"Fetch": "No Travel History"})
+    else:
+        orders = list(filter(
+            lambda x: "Reload agreement" in x.values() or "Reload" in x.values() or "Rejsekort ordered" in x.values() or "Top-up" in x.values(),
+            dataset))
+        # Remove empty key-values and empty objects from orders
+        orders = [{k: v for k, v in d.items() if v} for d in orders]
+
+        journeys = list(filter(lambda x: x not in orders, dataset))
+        # Remove empty key-values and empty objects from journeys
+        journeys = [{k: v for k, v in d.items() if v} for d in journeys]
+
+        data: dict[str, list[dict]] = {
+            "journeys": list(filter(bool, journeys)),
+            "orders": list(filter(bool, orders))
+        }
+
+    return json.dumps(data, indent=2, ensure_ascii=False)

--- a/functions/user.py
+++ b/functions/user.py
@@ -2,25 +2,9 @@ from functions import shared
 from bs4 import BeautifulSoup
 
 
-def fetch_user_details(session, token):
-    """
-    Fetch the user details from the website.
-
-    Args:
-    session (requests.Session): The session object with the user's cookies.
-    token (str): The __RequestVerificationToken value.
-
-    Returns:
-    dict: A dictionary containing the user's details.
-
-    Raises:
-    ValueError: If the __RequestVerificationToken input tag is not found in the HTML page.
-    ValueError: If the myInformationReadOnlyTable is not found in the HTML page.
-    """
-
+def get_details():
     # Fetch the user details from the website
-    details = session.get(shared.base_url + '/CWS/CustomerManagement/MyInformation',
-                          data={'__RequestVerificationToken': token}, timeout=shared.requests_timeout)
+    details = shared.session.get(shared.base_url + '/CWS/CustomerManagement/MyInformation', timeout=shared.requests_timeout)
 
     soup = BeautifulSoup(details.text, "lxml")
     my_info_container = soup.find('div', {"id": "readonlyDisplay"})
@@ -45,6 +29,7 @@ def fetch_user_details(session, token):
                 info_details[key] = value
 
     return info_details
+
 
 
 # ChangeUsername: /CWS/CustomerManagement/ChangeUsername


### PR DESCRIPTION
## Changelog
### Change:
* separate `authentication` and `travel history` functions and endpoints
* take separate parameters for both `/login` and `/fetch` endpoints

### Add:
* cookie expiry date/time to `/login` response.

**Note:**
* this means that client decides when to refresh the cookie/token by hitting login again.