### PR TITLE
skip google auth if workflow is executed by dependabot

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -26,6 +26,7 @@ jobs:
         run: bandit app.py functions/*.py
 
       - name: Authenticate with Google Cloud
+        if: github.actor != 'dependabot[bot]'
         id: auth
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
## Changelog
### Change
* skip google-github-auth when PR is opened by dependabot